### PR TITLE
Add declaration for unsigncookie helper

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -105,6 +105,7 @@ declare namespace session {
   }
 
   function getCookieValue(req: express.Request, name: string, secret?: string): string;
+  function unsigncookie(val: string, secrets: string[]): string | boolean;
 }
 
 export = session;


### PR DESCRIPTION
Add forgotten typescript declaration for the `unsigncookie` helper function that has been exported.